### PR TITLE
Add installation instructions hint to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-﻿ # Craft
+# Craft
  Craft is a cross platform package manager providing source builds, as well as binary artifacts, for hundreds of libraries, Qt and KDE Frameworks.
 
-# Getting started
-[Seting up Craft](https://community.kde.org/Craft)
+## Getting started
+[Setting up Craft](https://community.kde.org/Craft) (includes installation instructions)
 
-# Projects using Craft
+## Projects using Craft
 * [KDE BinaryFactory: Binaries for KDE applications](https://binary-factory.kde.org/)
 * [ownCloud](https://github.com/owncloud/client)
     * ```craft --add-blueprint-repository https://github.com/owncloud/craft-blueprints-owncloud.git```
@@ -14,7 +14,7 @@
 * [KDAB GammaRay](https://github.com/KDAB/GammaRay)
     * ```craft gammaray```
 
-# Getting in Touch
+## Getting in Touch
 
 [IRC :#kde-windows](http://webchat.freenode.net?channels=%23kde-windows)
 


### PR DESCRIPTION
A user must not necessarily recognize that setup instructions contain
installation instructions.