### PR TITLE
win: Fix typos in StartMenuFolder var, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * [ownCloud](https://github.com/owncloud/client)
     * ```craft --add-blueprint-repository https://github.com/owncloud/craft-blueprints-owncloud.git```
     * ```craft owncloud-client```
-* [Quasel IRC](https://github.com/quassel/quassel)
+* [Quassel IRC](https://github.com/quassel/quassel)
     * ```craft --add-blueprint-repository https://github.com/quassel/craft-blueprints-quassel.git```
     * ```craft quassel```
 * [KDAB GammaRay](https://github.com/KDAB/GammaRay)
@@ -17,7 +17,7 @@
 
 ## Getting in Touch
 
-[IRC :#kde-windows](http://webchat.freenode.net?channels=%23kde-windows)
+[IRC: #kde-windows](http://webchat.freenode.net?channels=%23kde-windows)
 
 [Report Bugs](https://phabricator.kde.org/project/profile/61/)
 

--- a/bin/Packager/Nsis/NullsoftInstaller.nsi
+++ b/bin/Packager/Nsis/NullsoftInstaller.nsi
@@ -164,10 +164,10 @@ SectionEnd
 Section
 SetShellVarContext all
 !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
-CreateDirectory "$SMPROGRAMS\$StartMenuFolde"
+CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
 SetOutPath $INSTDIR ; for working directory
 @{shortcuts}
-CreateShortCut "$SMPROGRAMS\$StartMenuFolde\Uninstall.lnk" "$INSTDIR\uninstall.exe"
+CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk" "$INSTDIR\uninstall.exe"
 !insertmacro MUI_STARTMENU_WRITE_END
 SectionEnd
 


### PR DESCRIPTION
## In brief

* Fix typos in `StartMenuFolder` variable
  * `$StartMenuFolde` → `$StartMenuFolder`
  * Should fix the application/uninstaller shortcut in Start Menu
* Fix typos in `README`

_As this is a trivial change, I've skipped the usual breakdown and analysis.  Only risk should be shortcuts being created in a still-wrong location._