### PR TITLE
pkg: Fix typo of StartMenuFolder in Nullsoft

### DIFF
--- a/bin/Packager/NullsoftInstallerPackager.py
+++ b/bin/Packager/NullsoftInstallerPackager.py
@@ -105,7 +105,7 @@ You can add your own defines into self.defines as well.
         return CraftCore.cache.getVersion(self.nsisExe, versionCommand="/VERSION") >= CraftVersion("3.03")
 
     def _createShortcut(self, name, target, icon="", parameter="", description="") -> str:
-        return  f"""CreateShortCut "$SMPROGRAMS\$StartMenuFolde\\{name}.lnk" "$INSTDIR\\{OsUtils.toNativePath(target)}" "{parameter}" "{icon}" 0 SW_SHOWNORMAL "" "{description}"\n"""
+        return  f"""CreateShortCut "$SMPROGRAMS\$StartMenuFolder\\{name}.lnk" "$INSTDIR\\{OsUtils.toNativePath(target)}" "{parameter}" "{icon}" 0 SW_SHOWNORMAL "" "{description}"\n"""
 
     def folderSize(self, path):
         total = 0


### PR DESCRIPTION
## In brief

* Fix typos in `StartMenuFolder` variable for Nullsoft packager
  * `$StartMenuFolde` → `$StartMenuFolder`
  * Should fix usage of `"executable"` and `"shortcuts"` package definitions

Seems I missed this the first time around, whoops.  Checking with `grep -F -R "StartMenuFolde\\"` appears to confirm this as the last one.

_As this is a trivial change, I've skipped the usual breakdown and analysis.  Only risk should be shortcuts being created in a still-wrong location._