### PR TITLE
Handle error when VC++ component is not installed

### DIFF
--- a/bin/CraftSetupHelper.py
+++ b/bin/CraftSetupHelper.py
@@ -190,6 +190,8 @@ class SetupHelper(object):
                 args += " -vcvars_ver=14.0"
         if not path:
             path = SetupHelper._callVCVER(version, native=native)
+        if not path:
+            log("Please ensure that you have installed the C++ component", critical=True)
 
         path = os.path.join(path, "VC")
         if not os.path.exists(os.path.join(path, "vcvarsall.bat")):


### PR DESCRIPTION
I was confused by this error:

```
python .\bin\craft.py craft
Failed to setup msvc compiler.
VC\Auxiliary\Build\vcvarsall.bat does not exist.
```