### PR TITLE
Fix bootstrap script --use-defaults option by using a tuple as default

### DIFF
--- a/setup/CraftBootstrap.py
+++ b/setup/CraftBootstrap.py
@@ -176,7 +176,7 @@ def getABI(args):
         abi, compiler = CraftBootstrap.promptForChoice("Select compiler",
                                                        [("Mingw-w64", ("mingw", "gcc")),
                                                         ("Microsoft Visual Studio 2019", ("msvc2019", "cl")),
-                                                        ], "Microsoft Visual Studio 2019", returnDefaultWithoutPrompt=args.use_defaults)
+                                                        ], ("msvc2019", "cl"), returnDefaultWithoutPrompt=args.use_defaults)
         abi += f"_64"
 
     elif CraftBootstrap.isAndroid():


### PR DESCRIPTION
Error was: 

`ValueError: too many values to unpack (expected 2)`