### PR TITLE
Fix two warnings and re-enable qt5 build on systems with modern cURL

### DIFF
--- a/bin/Packager/InnoSetupPackager.py
+++ b/bin/Packager/InnoSetupPackager.py
@@ -134,7 +134,7 @@ class InnoSetupPackager(PortablePackager):
                 f"""Root: HKA; Subkey: "Software\\Classes\\{ftype_id}"; ValueType: string; ValueName: ""; ValueData: "{ftype} file"; Flags: uninsdeletekey ; Tasks: {ftype_id}"""
             )
             registry_keys.append(
-                f"""Root: HKA; Subkey: "Software\\Classes\\{ftype_id}\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{{app}}\\{defines["executable"]},0" ; Tasks: {ftype_id}"""
+                f"""Root: HKA; Subkey: "Software\\Classes\\{ftype_id}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{{app}}\\{defines["executable"]},0" ; Tasks: {ftype_id}"""
             )
             registry_keys.append(
                 f"""Root: HKA; Subkey: "Software\\Classes\\{ftype_id}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: \"""{{app}}\\{defines["executable"]}"" ""%1""\" ; Tasks: {ftype_id}"""

--- a/bin/Utils/GetFiles.py
+++ b/bin/Utils/GetFiles.py
@@ -112,7 +112,7 @@ def getFile(url, destdir, filename="", quiet=None) -> bool:
 def curlFile(url, destdir, filename, quiet):
     """download file with curl from 'url' into 'destdir', if filename is given to the file specified"""
     curl = CraftCore.cache.findApplication("curl")
-    command = [curl, "-C", "-", "--retry", "10", "-L", "--ftp-ssl", "--fail"]
+    command = [curl, "-C", "-", "--retry", "10", "-L", "--fail"]
     cert = os.path.join(CraftCore.standardDirs.etcDir(), "cacert.pem")
     if os.path.exists(cert):
         command += ["--cacert", cert]

--- a/bin/VersionInfo.py
+++ b/bin/VersionInfo.py
@@ -176,7 +176,7 @@ class VersionInfo(object):
         Available variables:
         ${PACKAGE_NAME} : The name of the package
         ${VERSION} : The version of the package defined in version.ini
-        If the version matches \d.\d.\d there is also avalible:
+        If the version matches \\d.\\d.\\d there is also avalible:
             ${VERSION_MAJOR} : The first part of ${VERSION}
             ${VERSION_MINOR} : The secon part of ${VERSION}
             ${VERSION_PATCH_LEVEL} : The the third part of ${VERSION}


### PR DESCRIPTION
Hello,

This small PR contains fixes for a problems I stepped into while trying to install craft on modern system with Qt5 as default framework.